### PR TITLE
reflectPrimitive function - fix

### DIFF
--- a/lms-backend/src/main/scala/scalan/compilation/lms/LmsBridge.scala
+++ b/lms-backend/src/main/scala/scalan/compilation/lms/LmsBridge.scala
@@ -151,8 +151,9 @@ trait LmsBridge extends Passes {
 
     val lmsMethodMirror = lmsMirror.reflectMethod(lmsMethod)
 
-    val areParamsFunctions = lmsMethod.paramLists.flatten.map {
-      _.asTerm.typeSignature match {
+    // need to filter out SourceContext parameter
+    val areParamsFunctions = for (param <- lmsMethod.paramLists.flatten; if(param.asTerm.typeSignature != typeOf[SourceContext])) yield {
+      param.asTerm.typeSignature match {
         // we only check it's a function here, could check argument/result types if necessary
         case TypeRef(_, FunctionSym, _) => true
         case _ => false


### PR DESCRIPTION
In reflectPrimitive function - need to filter out SourceSontext parameter from areParamsFunction. Otherwise, the length of fieldMirrors and areParamsFunctions can differ. This leads to error when further using (e.g. zip in transformDef function).