### PR TITLE
tune travis jvm options

### DIFF
--- a/.travis.jvmopts
+++ b/.travis.jvmopts
@@ -1,4 +1,4 @@
--Xmx1536m
+-Xmx1g
 -Xss2m
 -XX:+CMSClassUnloadingEnabled
 -XX:+UseConcMarkSweepGC


### PR DESCRIPTION
Further CI jvm options optimization.

Tests on Travis sometimes fails with sbt fork error:
```
[error] ... sbt.ForkMain <pid> failed with exit code 137
```

This configuration had 8 consecutive successful runs
/cc @alexeyr 