### PR TITLE
[Structs] more tests for structWrapper + caching flags

### DIFF
--- a/core/src/main/scala/scalan/Base.scala
+++ b/core/src/main/scala/scalan/Base.scala
@@ -144,6 +144,10 @@ trait Base extends LazyLogging { self: Scalan =>
   def repDef_getElem[T <: Def[_]](x: Rep[T]): Elem[T]
 
   def reifyObject[A](d: Def[A]): Rep[A]
+
+  val cacheIsos = true
+  val cacheElems = true
+  val cachePairs = true
 }
 
 object Base {

--- a/core/src/main/scala/scalan/primitives/Tuples.scala
+++ b/core/src/main/scala/scalan/primitives/Tuples.scala
@@ -200,12 +200,16 @@ trait TuplesExp extends Tuples with BaseExp { self: ScalanExp =>
     case Def(Tup(a, b)) => (a, b)
     case _ => p.elem match {
       case pe: PairElem[_, _] =>
-        if (!tuplesCache.contains(p)) {
-          implicit val eA = pe.eFst
-          implicit val eB = pe.eSnd
-          tuplesCache.update(p, (First(p), Second(p)))
+        implicit val eA = pe.eFst
+        implicit val eB = pe.eSnd
+        if (cachePairs) {
+          if (!tuplesCache.contains(p)) {
+            tuplesCache.update(p, (First(p), Second(p)))
+          }
+          tuplesCache(p).asInstanceOf[(Rep[A], Rep[B])]
         }
-        tuplesCache(p).asInstanceOf[(Rep[A], Rep[B])]
+        else
+          (First(p), Second(p))
       case _ =>
         !!!(s"expected Tup[A,B] or Sym with type (A,B) but got ${p.toStringWithDefinition}")
     }


### PR DESCRIPTION
Caching of elements doesn't work for StructElem. It was hard to find it as the source of the bugs. 
I added global flags to turn on and off caching easily, mostly for debugging.
All places where caching is used should take this flags into account.