### PR TITLE
Emit graph on exception

### DIFF
--- a/core/src/main/scala/scalan/Base.scala
+++ b/core/src/main/scala/scalan/Base.scala
@@ -22,20 +22,22 @@ trait Base extends LazyLogging { self: Scalan =>
   type DoubleRep = Rep[Double]
   type :=>[-A, +B] = PartialFunction[A, B]
 
-  class StagingException(message: String, cause: Throwable) extends RuntimeException(message, cause) {
-    def this(message: String) = this(message, null)
+  protected def stagingExceptionMessage(message: String, syms: Seq[Rep[_]]): String
+
+  // Consider if extra data should be Seq[Any] instead (change name in this case)
+  class StagingException(message: String, cause: Throwable, val syms: Seq[Rep[_]]) extends
+  RuntimeException(stagingExceptionMessage(message, syms), cause) {
+    def this(message: String, syms: Seq[Rep[_]]) = this(message, null, syms)
   }
 
-  class ElemException[A](message: String)(implicit val element: Elem[A]) extends StagingException(message)
+  class NotImplementedStagingException(message: String, syms: Seq[Rep[_]]) extends StagingException(message, null, syms)
 
-  def ??? : Nothing = ???("not implemented")
-  def ???(value: Any): Nothing = throw new NotImplementedError(value.toString)
-  def ???(msg: String, syms: Rep[_]*): Nothing = throw new StagingException(msg + " " + syms.mkString)
+  def ??? : Nothing = ???("Missing or incomplete implementation")
+  def ???(value: Any, syms: Rep[_]*): Nothing = throw new NotImplementedStagingException(value.toString, syms)
 
   def !!! : Nothing = !!!("should not be called")
-  def !!!(msg: String): Nothing = throw new StagingException(msg)
-  def !!!(msg: String, syms: Rep[_]*): Nothing = throw new StagingException(msg + " " + syms.mkString)
-  def !!!(msg: String, e: Throwable): Nothing = throw new StagingException(msg, e)
+  def !!!(msg: String, syms: Rep[_]*): Nothing = throw new StagingException(msg, syms)
+  def !!!(msg: String, e: Throwable, syms: Rep[_]*): Nothing = throw new StagingException(msg, e, syms)
 
   implicit class RepForSomeExtension(x: Rep[_]) {
     def asRep[T]: Rep[T] = x.asInstanceOf[Rep[T]]
@@ -133,7 +135,7 @@ trait Base extends LazyLogging { self: Scalan =>
 
   abstract class CompanionDef[T] extends Def[T] {
     override def productArity = 0
-    override def productElement(n: Int) = ???
+    override def productElement(n: Int) = !!!(s"productElement($n) called, but productArity = 0", self)
     override def canEqual(other: Any) = other.isInstanceOf[CompanionDef[_]]
   }
 

--- a/core/src/main/scala/scalan/Entities.scala
+++ b/core/src/main/scala/scalan/Entities.scala
@@ -80,7 +80,7 @@ trait Entities extends Elems { self: Scalan =>
     case _: ViewElem[_,_] => true
     case _: EntityElem[_] => false
     case _: BaseElem[_] => true
-    case _ => !!!(s"isConcrete is not defined for Elem $e")
+    case _ => ???(s"isConcreteElem is not implemented for $e")
   }
 
   implicit class ElemOps[T](e: Elem[T]) {
@@ -116,7 +116,7 @@ trait Entities extends Elems { self: Scalan =>
     def convertTo[R <: Def[_]](implicit eR: Elem[R]): Rep[R] =
       eR match {
         case entE: EntityElem[R] @unchecked => entE.convert(x)
-        case _ => !!!(s"Cannot convert $x to a value of type ${eR.name}: EntityElem expected but ${eR.getClass.getSimpleName} found")
+        case _ => !!!(s"Cannot convert $x to a value of type ${eR.name}: EntityElem expected but ${eR.getClass.getSimpleName} found", x)
       }
   }
 }

--- a/core/src/main/scala/scalan/JNIExtractorOps.scala
+++ b/core/src/main/scala/scalan/JNIExtractorOps.scala
@@ -166,7 +166,7 @@ trait JNIExtractorOpsExp extends JNIExtractorOps { self: ScalanExp with Abstract
                 res.asRep[I]
             }
           case elem =>
-            ???(s"Don't know how to extract: elem = ${elem}")
+            ???(s"Don't know how to extract: elem = ${elem}", x)
 //        }
     }
   }
@@ -228,10 +228,10 @@ trait JNIExtractorOpsExp extends JNIExtractorOps { self: ScalanExp with Abstract
           case e if e.tag.tpe <:< TypeTag.AnyVal.tpe =>
             JNI_NewPrimitive(x)(el)
           case _ =>
-            ???(s"Don't know haw to pack: elem = ${el}")
+            ???(s"Don't know how to pack: elem = ${el}", x)
         }
       case elem =>
-        ???(s"Don't know haw to pack: elem = ${elem}")
+        ???(s"Don't know how to pack: elem = ${elem}", x)
     }
   }
 

--- a/core/src/main/scala/scalan/collections/ArrayBuffer.scala
+++ b/core/src/main/scala/scalan/collections/ArrayBuffer.scala
@@ -291,7 +291,7 @@ trait ArrayBuffersExp extends ArrayBuffers with ViewsDslExp { self: ScalanExp =>
         case ae: ArrayBufferElem[_] => ArrayBufferRep(sym)(ae.asInstanceOf[ArrayBufferElem[T]].eItem)
       }
     }
-    case _ => ???("cannot resolve DefObject for symbol:", sym)
+    case _ => ???("cannot resolve ArrayBuffer", sym)
   }
 
 }

--- a/core/src/main/scala/scalan/collections/Maps.scala
+++ b/core/src/main/scala/scalan/collections/Maps.scala
@@ -208,7 +208,7 @@ trait MapsExp extends Maps { self: ScalanExp =>
       val pmElem = s.elem.asInstanceOf[MMapElem[K, V]]
       VarMM(sym)(pmElem.eKey, pmElem.eValue)
     }
-    case _ => ???("cannot resolve DefObject for symbol:", sym)
+    case _ => ???("cannot resolve MMap", sym)
   }
 }
 /*

--- a/core/src/main/scala/scalan/impl/ConvertersImpl.scala
+++ b/core/src/main/scala/scalan/impl/ConvertersImpl.scala
@@ -39,7 +39,7 @@ trait ConvertersAbs extends Converters {
     def convertConverter(x: Rep[Converter[T, R]]): Rep[To] = {
       x.selfType1 match {
         case _: ConverterElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have ConverterElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have ConverterElem[_, _, _], but got $e", x)
       }
     }
 

--- a/core/src/main/scala/scalan/impl/ViewsImpl.scala
+++ b/core/src/main/scala/scalan/impl/ViewsImpl.scala
@@ -44,7 +44,7 @@ trait ViewsAbs extends Views {
     def convertIsoUR(x: Rep[IsoUR[From, To]]): Rep[To0] = {
       x.selfType1 match {
         case _: IsoURElem[_, _, _] => x.asRep[To0]
-        case e => !!!(s"Expected $x to have IsoURElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have IsoURElem[_, _, _], but got $e", x)
       }
     }
 
@@ -96,7 +96,7 @@ trait ViewsAbs extends Views {
     def convertIso1UR(x: Rep[Iso1UR[A, B, C]]): Rep[To] = {
       x.selfType1.asInstanceOf[Elem[_]] match {
         case _: Iso1URElem[_, _, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have Iso1URElem[_, _, _, _], but got $e")
+        case e => !!!(s"Expected $x to have Iso1URElem[_, _, _, _], but got $e", x)
       }
     }
 

--- a/core/src/main/scala/scalan/primitives/Functions.scala
+++ b/core/src/main/scala/scalan/primitives/Functions.scala
@@ -261,7 +261,7 @@ trait FunctionsExp extends Functions with BaseExp with ProgramGraphs { self: Sca
               if (f.isRecursive)
                 Apply(f, x)
               else
-                !!!(s"Stack overflow in applying non-recursive $f($x)", e)
+                !!!(s"Stack overflow in applying non-recursive $f($x)", e, f, x)
           }
         case Def(Apply(_, _)) => // function that is a result of Apply (curried application)
           Apply(f, x)

--- a/core/src/main/scala/scalan/primitives/Structs.scala
+++ b/core/src/main/scala/scalan/primitives/Structs.scala
@@ -331,7 +331,7 @@ trait StructsSeq extends Structs { self: ScalanSeq =>
   def field(struct: Rep[Struct], field: String): Rep[_] =
     struct.asInstanceOf[StructSeq[_]].fields.find(_._1 == field) match {
       case Some((_, value)) => value
-      case None => !!!(s"Field $field not found in structure $struct")
+      case None => !!!(s"Field $field not found in structure $struct", struct)
     }
   def fields(struct: Rep[Struct], fields: Seq[String]): Rep[Struct] = {
     val StructSeq(tag, fieldsInStruct) = struct

--- a/core/src/main/scala/scalan/primitives/Tuples.scala
+++ b/core/src/main/scala/scalan/primitives/Tuples.scala
@@ -211,7 +211,7 @@ trait TuplesExp extends Tuples with BaseExp { self: ScalanExp =>
         else
           (First(p), Second(p))
       case _ =>
-        !!!(s"expected Tup[A,B] or Sym with type (A,B) but got ${p.toStringWithDefinition}")
+        !!!(s"expected Tup[A,B] or Sym with type (A,B) but got ${p.toStringWithDefinition}", p)
     }
   }
 

--- a/core/src/main/scala/scalan/primitives/impl/AbstractStringsImpl.scala
+++ b/core/src/main/scala/scalan/primitives/impl/AbstractStringsImpl.scala
@@ -35,7 +35,7 @@ trait AbstractStringsAbs extends scalan.Scalan with AbstractStrings {
     def convertAString(x: Rep[AString]): Rep[To] = {
       x.selfType1 match {
         case _: AStringElem[_] => x.asRep[To]
-        case e => !!!(s"Expected $x to have AStringElem[_], but got $e")
+        case e => !!!(s"Expected $x to have AStringElem[_], but got $e", x)
       }
     }
 

--- a/core/src/main/scala/scalan/seq/BaseSeq.scala
+++ b/core/src/main/scala/scalan/seq/BaseSeq.scala
@@ -6,6 +6,8 @@ import scalan.{Base, ScalanSeq}
 trait BaseSeq extends Base { self: ScalanSeq =>
   type Rep[+A] = A
 
+  override protected def stagingExceptionMessage(message: String, syms: Seq[Rep[_]]) = message
+
   override def toRep[A](x: A)(implicit eA: Elem[A]) = x
 
   override def def_unapply[A](e: Rep[A]): Option[Def[A]] = e match {

--- a/core/src/main/scala/scalan/staged/AstGraphs.scala
+++ b/core/src/main/scala/scalan/staged/AstGraphs.scala
@@ -354,12 +354,6 @@ trait AstGraphs extends TransformingExp { self: ScalanExp =>
     */
   case class LambdaBranches(ifBranches: Map[Exp[_], IfBranches], assignments: Map[Exp[_], BranchPath])
 
-  implicit class AstGraphOps(graph: AstGraph) {
-    def startsWith(other: AstGraph): Boolean = {
-      ???
-    }
-  }
-
   def buildScheduleForResult(st: Seq[Exp[_]], neighbours: Exp[_] => Seq[Exp[_]]): Schedule = {
     val startNodes = st.flatMap(e => findDefinition(e).toList)
     val lambdas = startNodes.flatMap(_.lambda).toSet

--- a/core/src/main/scala/scalan/staged/Expressions.scala
+++ b/core/src/main/scala/scalan/staged/Expressions.scala
@@ -71,6 +71,26 @@ trait BaseExp extends Base { scalan: ScalanExp =>
     def merge(other: Ctx): Ctx = ops.merge(self, other)
   }
 
+  override protected def stagingExceptionMessage(message: String, syms: Seq[Exp[_]]) = {
+    // Skip syms already in the message, assume that's the only source for s<N>
+    val symsNotInMessage = syms.map(_.toString).filterNot(message.contains)
+
+    if (symsNotInMessage.isEmpty) {
+      message
+    } else {
+      val between = if (message.isEmpty)
+        ""
+      else
+        message.last match {
+          // determine whether the message lacks ending punctuation
+          case '.' | ';' | '!' | '?' => " "
+          case _ => ". "
+        }
+
+      message + between + s"Sym${if (symsNotInMessage.length > 1) "s" else ""}: ${symsNotInMessage.mkString(", ")}"
+    }
+  }
+
   private[this] case class ReflectedProductClass(constructor: Constructor[_], paramFieldMirrors: List[FieldMirror], hasScalanParameter: Boolean)
 
   private[this] val selfTypeSym =

--- a/core/src/main/scala/scalan/staged/TransformingExp.scala
+++ b/core/src/main/scala/scalan/staged/TransformingExp.scala
@@ -92,7 +92,7 @@ trait TransformingExp extends Transforming { self: ScalanExp =>
             if (e.isInstanceOf[DelayInvokeException])
               x
             else
-              !!!(s"Failed to invoke $call", e)
+              !!!(s"Failed to invoke $call", e, x)
           case _ => x
         }
       case _ => x

--- a/core/src/main/scala/scalan/util/impl/ExceptionsImpl.scala
+++ b/core/src/main/scala/scalan/util/impl/ExceptionsImpl.scala
@@ -44,7 +44,7 @@ trait ExceptionsAbs extends scalan.Scalan with Exceptions {
     def convertSThrowable(x: Rep[SThrowable]): Rep[To] = {
       x.selfType1 match {
         case _: SThrowableElem[_] => x.asRep[To]
-        case e => !!!(s"Expected $x to have SThrowableElem[_], but got $e")
+        case e => !!!(s"Expected $x to have SThrowableElem[_], but got $e", x)
       }
     }
     lazy val baseElem = {

--- a/core/src/test/scala/scalan/MetadataTests.scala
+++ b/core/src/test/scala/scalan/MetadataTests.scala
@@ -22,7 +22,7 @@ class MetadataTests extends BaseNestedTests {
       import compiler._
       import compiler.scalan._
 
-      val graph = buildGraph(FileUtil.currentWorkingDir, mainStr, main, GraphVizConfig.none)(defaultCompilerConfig)
+      val graph = buildGraph(FileUtil.currentWorkingDir, mainStr, main, GraphVizConfig.none)(defaultCompilerConfig).graph
 
       val finalMain = graph.roots.head
 
@@ -47,7 +47,7 @@ class MetadataTests extends BaseNestedTests {
       import compiler._
       import compiler.scalan._
 
-      val graph = buildGraph(FileUtil.currentWorkingDir, mainStr, main, GraphVizConfig.none)(defaultCompilerConfig)
+      val graph = buildGraph(FileUtil.currentWorkingDir, mainStr, main, GraphVizConfig.none)(defaultCompilerConfig).graph
 
       val finalMain = graph.roots.head
 

--- a/core/src/test/scala/scalan/TestContexts.scala
+++ b/core/src/test/scala/scalan/TestContexts.scala
@@ -26,10 +26,10 @@ trait TestContexts extends TestsUtil {
     val compiler: Compiler[_ <: ScalanExp]
     import compiler._
 
-    def test[A,B](functionName: String, f: Exp[A => B]): CompilerOutput[A, B] = {
+    def test[A,B](functionName: String, f: => Exp[A => B]): CompilerOutput[A, B] = {
       buildExecutable(FileUtil.file(prefix, functionName), functionName, f, GraphVizConfig.default)(defaultCompilerConfig)
     }
-    def test[A,B](f: Exp[A => B]): CompilerOutput[A, B] = test(testName, f)
+    def test[A,B](f: => Exp[A => B]): CompilerOutput[A, B] = test(testName, f)
 
     def emit(name: String, ss: scalan.Exp[_]*): Unit =
       scalan.emitDepGraph(ss, FileUtil.file(prefix, testName, s"$name.dot"))(scalan.defaultGraphVizConfig)

--- a/core/src/test/scala/scalan/common/impl/KindsImpl.scala
+++ b/core/src/test/scala/scalan/common/impl/KindsImpl.scala
@@ -37,7 +37,7 @@ trait KindsAbs extends scalan.Scalan with Kinds {
     def convertKind(x: Rep[Kind[F, A]]): Rep[To] = {
       x.selfType1.asInstanceOf[Elem[_]] match {
         case _: KindElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have KindElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have KindElem[_, _, _], but got $e", x)
       }
     }
 

--- a/core/src/test/scala/scalan/common/impl/MetaTestsImpl.scala
+++ b/core/src/test/scala/scalan/common/impl/MetaTestsImpl.scala
@@ -35,7 +35,7 @@ trait MetaTestsAbs extends scalan.Scalan with MetaTests {
     def convertMetaTest(x: Rep[MetaTest[T]]): Rep[To] = {
       x.selfType1 match {
         case _: MetaTestElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have MetaTestElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have MetaTestElem[_, _], but got $e", x)
       }
     }
 

--- a/core/src/test/scala/scalan/common/impl/SegmentsImpl.scala
+++ b/core/src/test/scala/scalan/common/impl/SegmentsImpl.scala
@@ -35,7 +35,7 @@ trait SegmentsAbs extends scalan.Scalan with Segments {
     def convertSegment(x: Rep[Segment]): Rep[To] = {
       x.selfType1 match {
         case _: SegmentElem[_] => x.asRep[To]
-        case e => !!!(s"Expected $x to have SegmentElem[_], but got $e")
+        case e => !!!(s"Expected $x to have SegmentElem[_], but got $e", x)
       }
     }
 

--- a/core/src/test/scala/scalan/it/ItTestsUtil.scala
+++ b/core/src/test/scala/scalan/it/ItTestsUtil.scala
@@ -62,8 +62,9 @@ trait ItTestsUtil[Prog <: Scalan] extends TestsUtil {
                             graphVizConfig: GraphVizConfig = defaultGraphVizConfig,
                             functionName: String = currentTestNameAsFileName)(inputs: A*) = {
     val compiled = compilers.map { cwc =>
-      val fExp = f(cwc.compiler.scalan).asInstanceOf[cwc.compiler.Exp[A => B]]
-      val out = cwc.compiler.buildExecutable(sourceDir(functionName), functionName, fExp, graphVizConfig)(cwc.config)
+      val out = cwc.compiler.buildExecutable(sourceDir(functionName), functionName,
+        f(cwc.compiler.scalan).asInstanceOf[cwc.compiler.Exp[A => B]],
+        graphVizConfig)(cwc.config)
       (cwc.compiler, out)
     }
 
@@ -88,8 +89,9 @@ trait ItTestsUtil[Prog <: Scalan] extends TestsUtil {
                                       graphVizConfig: GraphVizConfig = defaultGraphVizConfig,
                                       functionName: String = currentTestNameAsFileName)(inputsOutputs: (A, B)*) = {
     val compiled = compilers.map { cwc =>
-      val fExp = f(cwc.compiler.scalan).asInstanceOf[cwc.compiler.Exp[A => B]]
-      val out = cwc.compiler.buildExecutable(sourceDir(functionName), functionName, fExp, graphVizConfig)(cwc.config)
+      val out = cwc.compiler.buildExecutable(sourceDir(functionName), functionName,
+        f(cwc.compiler.scalan).asInstanceOf[cwc.compiler.Exp[A => B]],
+        graphVizConfig)(cwc.config)
       (cwc.compiler, out)
     }
 

--- a/core/src/test/scala/scalan/primitives/StructTests.scala
+++ b/core/src/test/scala/scalan/primitives/StructTests.scala
@@ -182,7 +182,7 @@ class StructTests extends BaseViewTests {
     val ctx = new Ctx {
       import compiler.scalan._
       def testWrapper[A,B](functionName: String,
-                             f: Exp[A => B], expectTuples: Boolean = false): compiler.CompilerOutput[A, B] = {
+                             f: => Exp[A => B], expectTuples: Boolean = false): compiler.CompilerOutput[A, B] = {
         val out = super.test(functionName, f)
         val hasTuples = !noTuples(out.common.graph.roots(0).asRep[A => B])
         assert(expectTuples && hasTuples || (!expectTuples && !hasTuples))

--- a/library/src/main/scala/scalan/PointerOps.scala
+++ b/library/src/main/scala/scalan/PointerOps.scala
@@ -55,7 +55,7 @@ trait PointerOpsExp extends PointerOps { self: ScalanExp =>
   def scalarPtr[A: Elem](source: Exp[A]): Exp[Pointer[A]] = {
     source.elem match {
       case be: BaseElem[_] => ScalarPtr(CreateScalar(source))
-      case _ => !!!(s"not allowed to make scalar pointer for non-BaseElem: ${source.elem}")
+      case _ => !!!(s"not allowed to make scalar pointer for non-BaseElem: ${source.elem}", source)
     }
   }
 

--- a/library/src/main/scala/scalan/collections/impl/BitSetsImpl.scala
+++ b/library/src/main/scala/scalan/collections/impl/BitSetsImpl.scala
@@ -35,7 +35,7 @@ trait BitSetsAbs extends scalan.Scalan with BitSets {
     def convertBitSet(x: Rep[BitSet]): Rep[To] = {
       x.selfType1 match {
         case _: BitSetElem[_] => x.asRep[To]
-        case e => !!!(s"Expected $x to have BitSetElem[_], but got $e")
+        case e => !!!(s"Expected $x to have BitSetElem[_], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/collections/impl/CollectionsImpl.scala
+++ b/library/src/main/scala/scalan/collections/impl/CollectionsImpl.scala
@@ -42,7 +42,7 @@ trait CollectionsAbs extends scalan.Scalan with Collections {
     def convertCollection(x: Rep[Collection[Item]]): Rep[To] = {
       x.selfType1 match {
         case _: CollectionElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have CollectionElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have CollectionElem[_, _], but got $e", x)
       }
     }
 
@@ -93,7 +93,7 @@ trait CollectionsAbs extends scalan.Scalan with Collections {
     def convertPairCollection(x: Rep[PairCollection[A, B]]): Rep[To] = {
       x.selfType1 match {
         case _: PairCollectionElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have PairCollectionElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have PairCollectionElem[_, _, _], but got $e", x)
       }
     }
 
@@ -129,7 +129,7 @@ trait CollectionsAbs extends scalan.Scalan with Collections {
     def convertNestedCollection(x: Rep[NestedCollection[A]]): Rep[To] = {
       x.selfType1 match {
         case _: NestedCollectionElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have NestedCollectionElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have NestedCollectionElem[_, _], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/collections/impl/HashSetsImpl.scala
+++ b/library/src/main/scala/scalan/collections/impl/HashSetsImpl.scala
@@ -71,7 +71,7 @@ trait HashSetsAbs extends scalan.Scalan with HashSets {
     def convertSHashSet(x: Rep[SHashSet[A]]): Rep[To] = {
       x.selfType1 match {
         case _: SHashSetElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have SHashSetElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have SHashSetElem[_, _], but got $e", x)
       }
     }
     lazy val baseElem =

--- a/library/src/main/scala/scalan/collections/impl/MultiMapImpl.scala
+++ b/library/src/main/scala/scalan/collections/impl/MultiMapImpl.scala
@@ -38,7 +38,7 @@ trait MultiMapsAbs extends scalan.Scalan with MultiMaps {
     def convertMMultiMap(x: Rep[MMultiMap[K, V]]): Rep[To] = {
       x.selfType1 match {
         case _: MMultiMapElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have MMultiMapElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have MMultiMapElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/collections/impl/SeqsImpl.scala
+++ b/library/src/main/scala/scalan/collections/impl/SeqsImpl.scala
@@ -73,7 +73,7 @@ trait SeqsAbs extends scalan.Scalan with Seqs {
     def convertSSeq(x: Rep[SSeq[A]]): Rep[To] = {
       x.selfType1 match {
         case _: SSeqElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have SSeqElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have SSeqElem[_, _], but got $e", x)
       }
     }
     lazy val baseElem =

--- a/library/src/main/scala/scalan/graphs/impl/EdgesImpl.scala
+++ b/library/src/main/scala/scalan/graphs/impl/EdgesImpl.scala
@@ -40,7 +40,7 @@ trait EdgesAbs extends scalan.Scalan with Edges {
     def convertEdge(x: Rep[Edge[V, E]]): Rep[To] = {
       x.selfType1 match {
         case _: EdgeElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have EdgeElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have EdgeElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/graphs/impl/FrontsImpl.scala
+++ b/library/src/main/scala/scalan/graphs/impl/FrontsImpl.scala
@@ -35,7 +35,7 @@ trait FrontsAbs extends scalan.Scalan with Fronts {
     def convertFront(x: Rep[Front]): Rep[To] = {
       x.selfType1 match {
         case _: FrontElem[_] => x.asRep[To]
-        case e => !!!(s"Expected $x to have FrontElem[_], but got $e")
+        case e => !!!(s"Expected $x to have FrontElem[_], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/graphs/impl/GraphsImpl.scala
+++ b/library/src/main/scala/scalan/graphs/impl/GraphsImpl.scala
@@ -41,7 +41,7 @@ trait GraphsAbs extends scalan.Scalan with Graphs {
     def convertGraph(x: Rep[Graph[V, E]]): Rep[To] = {
       x.selfType1 match {
         case _: GraphElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have GraphElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have GraphElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/graphs/impl/VerticesImpl.scala
+++ b/library/src/main/scala/scalan/graphs/impl/VerticesImpl.scala
@@ -40,7 +40,7 @@ trait VerticesAbs extends scalan.Scalan with Vertices {
     def convertVertex(x: Rep[Vertex[V, E]]): Rep[To] = {
       x.selfType1 match {
         case _: VertexElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have VertexElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have VertexElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/linalgebra/impl/MatricesImpl.scala
+++ b/library/src/main/scala/scalan/linalgebra/impl/MatricesImpl.scala
@@ -38,7 +38,7 @@ trait MatricesAbs extends scalan.Scalan with Matrices {
     def convertAbstractMatrix(x: Rep[AbstractMatrix[T]]): Rep[To] = {
       x.selfType1 match {
         case _: AbstractMatrixElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have AbstractMatrixElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have AbstractMatrixElem[_, _], but got $e", x)
       }
     }
 

--- a/library/src/main/scala/scalan/linalgebra/impl/VectorsImpl.scala
+++ b/library/src/main/scala/scalan/linalgebra/impl/VectorsImpl.scala
@@ -38,7 +38,7 @@ trait VectorsAbs extends scalan.Scalan with Vectors {
     def convertAbstractVector(x: Rep[AbstractVector[T]]): Rep[To] = {
       x.selfType1 match {
         case _: AbstractVectorElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have AbstractVectorElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have AbstractVectorElem[_, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/AuthsImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/AuthsImpl.scala
@@ -38,7 +38,7 @@ trait AuthenticationsAbs extends scalan.Scalan with Authentications {
     def convertAuth(x: Rep[Auth[A]]): Rep[To] = {
       x.selfType1 match {
         case _: AuthElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have AuthElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have AuthElem[_, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/CoproductsImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/CoproductsImpl.scala
@@ -39,7 +39,7 @@ trait CoproductsAbs extends scalan.Scalan with Coproducts {
     def convertCoproduct(x: Rep[Coproduct[F, G, A]]): Rep[To] = {
       x.selfType1.asInstanceOf[Elem[_]] match {
         case _: CoproductElem[_, _, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have CoproductElem[_, _, _, _], but got $e")
+        case e => !!!(s"Expected $x to have CoproductElem[_, _, _, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/FreeMsImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/FreeMsImpl.scala
@@ -39,7 +39,7 @@ trait FreeMsAbs extends scalan.Scalan with FreeMs {
     def convertFreeM(x: Rep[FreeM[F, A]]): Rep[To] = {
       x.selfType1.asInstanceOf[Elem[_]] match {
         case _: FreeMElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have FreeMElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have FreeMElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/FreeStatesImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/FreeStatesImpl.scala
@@ -40,7 +40,7 @@ trait FreeStatesAbs extends scalan.Scalan with FreeStates {
     def convertStateF(x: Rep[StateF[S, A]]): Rep[To] = {
       x.selfType1 match {
         case _: StateFElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have StateFElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have StateFElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/FreesImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/FreesImpl.scala
@@ -38,7 +38,7 @@ trait FreesAbs extends scalan.Scalan with Frees {
     def convertFree(x: Rep[Free[F, A]]): Rep[To] = {
       x.selfType1.asInstanceOf[Elem[_]] match {
         case _: FreeElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have FreeElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have FreeElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/IOsImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/IOsImpl.scala
@@ -38,7 +38,7 @@ trait IOsAbs extends scalan.Scalan with IOs {
     def convertIO(x: Rep[IO[A]]): Rep[To] = {
       x.selfType1 match {
         case _: IOElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have IOElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have IOElem[_, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/InteractionsImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/InteractionsImpl.scala
@@ -39,7 +39,7 @@ trait InteractionsAbs extends scalan.Scalan with Interactions {
     def convertInteract(x: Rep[Interact[A]]): Rep[To] = {
       x.selfType1 match {
         case _: InteractElem[_, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have InteractElem[_, _], but got $e")
+        case e => !!!(s"Expected $x to have InteractElem[_, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/ProcessesImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/ProcessesImpl.scala
@@ -39,7 +39,7 @@ trait ProcessesAbs extends scalan.Scalan with Processes {
     def convertProcess(x: Rep[Process[F, O]]): Rep[To] = {
       x.selfType1.asInstanceOf[Elem[_]] match {
         case _: ProcessElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have ProcessElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have ProcessElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/ReadersImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/ReadersImpl.scala
@@ -39,7 +39,7 @@ trait ReadersAbs extends scalan.Scalan with Readers {
     def convertReader(x: Rep[Reader[Env, A]]): Rep[To] = {
       x.selfType1 match {
         case _: ReaderElem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have ReaderElem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have ReaderElem[_, _, _], but got $e", x)
       }
     }
 

--- a/library/src/test/scala/scalan/effects/impl/StatesImpl.scala
+++ b/library/src/test/scala/scalan/effects/impl/StatesImpl.scala
@@ -39,7 +39,7 @@ trait StatesAbs extends scalan.Scalan with States {
     def convertState0(x: Rep[State0[S, A]]): Rep[To] = {
       x.selfType1 match {
         case _: State0Elem[_, _, _] => x.asRep[To]
-        case e => !!!(s"Expected $x to have State0Elem[_, _, _], but got $e")
+        case e => !!!(s"Expected $x to have State0Elem[_, _, _], but got $e", x)
       }
     }
 

--- a/lms-backend/src/it/scala/scalan/effects/EffectsItTests.scala
+++ b/lms-backend/src/it/scala/scalan/effects/EffectsItTests.scala
@@ -153,7 +153,7 @@ class EffectsJniItTests extends BaseItTests[State0Prog](???) {
   val defaultCompilers = compilers(progcxx)
 
   // FIXME temporary workaround for compileSource below not compiling
-  def generate[A, B](back: Compiler[_ <: ScalanCtxExp])(f: back.Exp[A => B], functionName: String)
+  def generate[A, B](back: Compiler[_ <: ScalanCtxExp])(f: => back.Exp[A => B], functionName: String)
                     (implicit config: back.CompilerConfig): Unit = {
     val dir = new File(prefix, functionName)
     back.buildExecutable(dir, dir, functionName, f, GraphVizConfig.default)

--- a/lms-backend/src/it/scala/scalan/it/lms/PointerItTests.scala
+++ b/lms-backend/src/it/scala/scalan/it/lms/PointerItTests.scala
@@ -46,7 +46,7 @@ class PointerItTests extends BaseItTests[PointerProg](???) {
   val defaultCompilers = compilers(progExp)
   implicit val cfg = progExp.defaultCompilerConfig
 
-  def commonTestScenario[A, B](functionName: String, func: progExp.Exp[A => B]): Unit = {
+  def commonTestScenario[A, B](functionName: String, func: => progExp.Exp[A => B]): Unit = {
     val dir = new File(prefix, functionName)
     progExp.buildExecutable(dir, dir, functionName, func, GraphVizConfig.default)
     println("cxx file generated")

--- a/lms-backend/src/main/scala/scalan/compilation/lms/LmsCompiler.scala
+++ b/lms-backend/src/main/scala/scalan/compilation/lms/LmsCompiler.scala
@@ -12,61 +12,35 @@ abstract class LmsCompiler[+ScalanCake <: ScalanCtxExp](_scalan: ScalanCake) ext
 
   override def graphPasses(compilerConfig: CompilerConfig) = Seq(AllUnpackEnabler, AllInvokeEnabler)
 
-  def emitSource[A, B](sourcesDir: File, functionName: String, graph: PGraph, eInput: Elem[A], eOutput: Elem[B]): File = {
+  def emitSource[A, B](sourcesDir: File, functionName: String, graph: PGraph, eInput: Elem[A], eOutput: Elem[B], graphVizConfig: GraphVizConfig): File = {
     (elemToManifest(eInput), elemToManifest(eOutput)) match {
       case (mA: Manifest[a], mB: Manifest[b]) =>
 
-        // ***$$$*** transform graph in lms start
-        /*
-        val graphEmitter = new GraphLmsBackend
-        val codegen = graphEmitter.codegen
         val lmsFunc = apply[a, b](graph)
-        try {
-          codegen.emitSource[a, b](lmsFunc, functionName, writer)(mA, mB)
-        } catch {
-          case e: Throwable => {
-            println("ERROR in codegen.emitSource: " + e)
-          }
-        }
-        println("=== codegen.graphStream.roots.head.toString ===" )
-        println(codegen.graphStream.roots.head.toString)
-        println("===============================================" )
-        */
-        // ***$$$*** transform graph in lms stop
-
         val codegen = lms.codegen
-        val lmsFunc = apply[a, b](graph)
+        emitLmsGraph(sourcesDir, functionName, graphVizConfig, lmsFunc, mA, mB)
 
         codegen.createFile(lmsFunc, functionName, sourcesDir)(mA, mB)
 
     }
   }
 
-  override def buildGraph[A, B](sourcesDir: File, functionName: String, func: => Exp[A => B], graphVizConfig: GraphVizConfig)(compilerConfig: CompilerConfig): CommonCompilerOutput[A, B] = {
-    // pass scalan phases
-    val output = super.buildGraph(sourcesDir, functionName, func, graphVizConfig)(compilerConfig)
+  def emitLmsGraph[A, B](sourcesDir: File, functionName: String, graphVizConfig: GraphVizConfig, lmsFunc: lms.Exp[A] => lms.Exp[B], mA: Manifest[A], mB: Manifest[B]): Unit = {
+    val graphCodegen = lms.graphCodegen
 
-    (elemToManifest(output.eInput), elemToManifest(output.eOutput)) match {
-      case (mA: Manifest[a], mB: Manifest[b]) =>
-        val codegen = lms.graphCodegen
-        val lmsFunc = apply[a, b](output.graph)
-
-        val log = new File(sourcesDir, s"${functionName}_lms.log")
-        FileUtil.withFile(log) { writer =>
-          try {
-            codegen.emitSource[a, b](lmsFunc, functionName, writer)(mA, mB)
-          } catch {
-            case e: Exception =>
-              println("Exception in codegen.emitSource:")
-              e.printStackTrace()
-          }
-        }
-
-        val dotFile = new File(sourcesDir, s"${functionName}_lms.dot")
-
-        codegen.graphStream.exportToGraphVis(dotFile, graphVizConfig)
+    val log = new File(sourcesDir, s"${functionName}_lms.log")
+    FileUtil.withFile(log) { writer =>
+      try {
+        graphCodegen.emitSource[A, B](lmsFunc, functionName, writer)(mA, mB)
+      } catch {
+        case e: Exception =>
+          println("Exception in graphCodegen.emitSource:")
+          e.printStackTrace()
+      }
     }
 
-    output
+    val dotFile = new File(sourcesDir, s"${functionName}_lms.dot")
+
+    graphCodegen.graphStream.exportToGraphVis(dotFile, graphVizConfig)
   }
 }

--- a/lms-backend/src/main/scala/scalan/compilation/lms/cxx/LmsCompilerCxx.scala
+++ b/lms-backend/src/main/scala/scalan/compilation/lms/cxx/LmsCompilerCxx.scala
@@ -21,7 +21,7 @@ class LmsCompilerCxx[ScalanCake <: ScalanCtxExp](_scalan: ScalanCake) extends Lm
                                       (compilerConfig: CompilerConfig, eInput: Elem[A], eOutput: Elem[B]) = {
     /* LMS stuff */
 
-    emitSource(sourcesDir, functionName, graph, eInput, eOutput)
+    emitSource(sourcesDir, functionName, graph, eInput, eOutput, graphVizConfig)
 //    val command = Seq("scalac", "-d", jarPath(functionName, executableDir)) ++ config.extraCompilerOptions :+
 //      sourceFile.getAbsolutePath
 //

--- a/lms-backend/src/main/scala/scalan/compilation/lms/scalac/LmsCompilerScala.scala
+++ b/lms-backend/src/main/scala/scalan/compilation/lms/scalac/LmsCompilerScala.scala
@@ -33,7 +33,7 @@ abstract class LmsCompilerScala[+ScalanCake <: ScalanCtxExp](_scalan: ScalanCake
                                        (compilerConfig: CompilerConfig, eInput: Elem[A], eOutput: Elem[B]) = {
     Sbt.prepareDir(executableDir) //todo - check: is it sbt-specific function?
     /* LMS stuff */
-    val sourceFile = emitSource(sourcesDir, functionName, graph, eInput, eOutput)
+    val sourceFile = emitSource(sourcesDir, functionName, graph, eInput, eOutput, graphVizConfig)
     val jarFile = file(executableDir.getAbsoluteFile, s"$functionName.jar")
     FileUtil.deleteIfExist(jarFile)
     val jarPath = jarFile.getAbsolutePath

--- a/lms-backend/src/main/scala/scalan/compilation/lms/uni/LmsCompilerUni.scala
+++ b/lms-backend/src/main/scala/scalan/compilation/lms/uni/LmsCompilerUni.scala
@@ -3,6 +3,7 @@ package scalan.compilation.lms.uni
 import java.io.File
 import java.net.URL
 
+import scalan.compilation.GraphVizConfig
 import scalan.compilation.lms._
 import scalan.compilation.lms.common.JNILmsOpsExp
 import scalan.compilation.lms.cxx.sharedptr.CxxCodegen
@@ -63,7 +64,7 @@ class LmsCompilerUni[+ScalanCake <: ScalanCommunityDslExp with JNIExtractorOpsEx
   override def getClassLoader(jarUrls: Array[URL]): ClassLoader =
     new NativeCopyLoader(Seq.empty, Seq(new File(runtimeTargetDir)), jarUrls, getClass.getClassLoader)
 
-  override def emitSource[A, B](sourcesDir: File, functionName: String, graph: PGraph, eInput: Elem[A], eOutput: Elem[B]) = {
+  override def emitSource[A, B](sourcesDir: File, functionName: String, graph: PGraph, eInput: Elem[A], eOutput: Elem[B], graphVizConfig: GraphVizConfig) = {
     (elemToManifest(eInput), elemToManifest(eOutput)) match {
       case (mA: Manifest[a], mB: Manifest[b]) =>
         graph.roots.size match {
@@ -71,6 +72,7 @@ class LmsCompilerUni[+ScalanCake <: ScalanCommunityDslExp with JNIExtractorOpsEx
           case 1 => // just generate one scala file
             // call LmsMirror
             val lmsFunc = apply[a, b](graph)
+            emitLmsGraph(sourcesDir, functionName, graphVizConfig, lmsFunc, mA, mB)
             lms.codegen.createFile(lmsFunc, functionName, sourcesDir)(mA, mB)
 
           case _ => //generate some c++ files, and then generate scala file with native calls
@@ -79,6 +81,7 @@ class LmsCompilerUni[+ScalanCake <: ScalanCommunityDslExp with JNIExtractorOpsEx
 
             val cxxFunctions = findRootsForCodegen(graph, KnownCodegens.Cxx)
             for (f <- cxxFunctions) {
+              // TODO emit LMS graphs for them
               emitCSource(sourcesDir, functionName, finalMirror, f)
             }
 
@@ -86,6 +89,7 @@ class LmsCompilerUni[+ScalanCake <: ScalanCommunityDslExp with JNIExtractorOpsEx
             scalaFunctions match {
               case Seq(scalaFunction) =>
                 val lmsFunc = finalMirror.funcMirror[a, b](scalaFunction)
+                emitLmsGraph(sourcesDir, functionName, graphVizConfig, lmsFunc, mA, mB)
                 lms.jniCallCodegen.createFile(lmsFunc, functionName, sourcesDir)(mA, mB)
               case Seq() => !!!("There are no function marked for JVM code generation")
               case _ => !!!("There must be exactly one function marked for JVM code generation")

--- a/lms-backend/src/main/scala/scalan/compilation/lms/uni/LmsCompilerUni.scala
+++ b/lms-backend/src/main/scala/scalan/compilation/lms/uni/LmsCompilerUni.scala
@@ -27,7 +27,8 @@ class LmsCompilerUni[+ScalanCake <: ScalanCommunityDslExp with JNIExtractorOpsEx
 
   lazy val marker = new SymbolsMarkerForSelectCodegen[scalan.type](scalan)
 
-  override def buildInitialGraph[A, B](func: Exp[A => B])(compilerConfig: CompilerConfig): PGraph = {
+  // TODO can this be changed into an initial pass?
+  protected override def buildInitialGraph[A, B](func: Exp[A => B])(compilerConfig: CompilerConfig): PGraph = {
 
     val conf = compilerConfig.nativeMethods
     val needForAdapt = marker.mark(func, marker.defaultCompilationPipelineContext, conf)
@@ -49,14 +50,12 @@ class LmsCompilerUni[+ScalanCake <: ScalanCommunityDslExp with JNIExtractorOpsEx
       }
     }
 
-    needForAdapt.length match {
-      case 0 =>
-        new PGraph(func)
-      case _ => {
-        val rootList = (needForAdapt flatMap ( f => adapt(f)))
-        new PGraph(rootList)
-      }
-    }
+    val roots = if (needForAdapt.isEmpty)
+      List(func)
+    else
+      needForAdapt.flatMap(adapt)
+
+    new PGraph(roots)
   }
 
   val runtimeTargetDir = Base.config.getProperty("runtime.target")

--- a/meta/src/main/scala/scalan/meta/ScalanCodegen.scala
+++ b/meta/src/main/scala/scalan/meta/ScalanCodegen.scala
@@ -473,7 +473,7 @@ object ScalanCodegen extends SqlCompiler with ScalanAstExtensions {
         |    def convert${e.name}(x: Rep[${e.typeUse}]): Rep[$toArgName] = {
         |      x.selfType1${e.t.isHighKind.opt(".asInstanceOf[Elem[_]]")} match {
         |        case _: $wildcardElem => x.asRep[$toArgName]
-        |        case e => !!!(s"Expected $$x to have $wildcardElem, but got $$e")
+        |        case e => !!!(s"Expected $$x to have $wildcardElem, but got $$e", x)
         |      }
         |    }
         |${e.isWrapper.opt(baseTypeElem)}


### PR DESCRIPTION
Allows generation of partial graphs when exception is thrown. Quite useful when debugging a failure.