### PR TITLE
fix build timeouts on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,4 +45,4 @@ install:
     fi
 
 script:
-  - sbt -jvm-opts .travis.jvmopts $TEST_SUITE
+  - travis_wait sbt -jvm-opts .travis.jvmopts $TEST_SUITE


### PR DESCRIPTION
By default, Travis let command run 10 minutes without output.
`travis_wait` increases this timeout to 20 minutes by writing short line every minute.