### PR TITLE
[Meta] Use non-interactive compiler to parse Scala code

### DIFF
--- a/meta/src/main/scala/scalan/meta/ScalanParsers.scala
+++ b/meta/src/main/scala/scalan/meta/ScalanParsers.scala
@@ -5,13 +5,14 @@
 package scalan.meta
 
 import scala.language.implicitConversions
+import scala.tools.nsc.Global
 import scala.reflect.internal.util.RangePosition
 import scala.reflect.internal.util.OffsetPosition
 import scalan.meta.ScalanAst._
 
 trait ScalanParsers {
 
-  type Compiler <: scala.tools.nsc.Global
+  type Compiler = Global
   val compiler: Compiler
   import compiler._
 

--- a/meta/src/main/scala/scalan/meta/ScalanParsersEx.scala
+++ b/meta/src/main/scala/scalan/meta/ScalanParsersEx.scala
@@ -1,23 +1,29 @@
 package scalan.meta
 
 import java.io.File
-import scala.tools.nsc.interactive.Global
+import scala.tools.nsc.Global
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
 import scala.reflect.internal.util.SourceFile
 
 trait ScalanParsersEx extends ScalanParsers {
-  type Compiler = scala.tools.nsc.interactive.Global
   val settings = new Settings
   settings.embeddedDefaults(getClass.getClassLoader)
   settings.usejavacp.value = true
   val reporter = new StoreReporter
   val compiler: Compiler = new Global(settings, reporter)
 
-  def parseEntityModule(file: File) = {
-    val source = compiler.getSourceFile(file.getPath)
-    val tree = compiler.parseTree(source)
+  // Credit due to Li Haoyi in Ammonite:
+  // Initialize scalac to the parser phase immediately, so we can start
+  // using Compiler#parse even if we haven't compiled any compilation
+  // units yet due to caching
+  val run = new compiler.Run()
+  compiler.phase = run.parserPhase
+  run.cancel()
 
+  def parseEntityModule(file: File) = {
+    val sourceFile = compiler.getSourceFile(file.getPath)
+    val tree = parseFile(sourceFile)
     parse(file.getPath, tree)
   }
 


### PR DESCRIPTION
This should avoid `InterruptedException` after parsing finishes and so
fix #35.