### PR TITLE
[Core] Move next id calculation to a separate method

### DIFF
--- a/core/src/main/scala/scalan/primitives/Structs.scala
+++ b/core/src/main/scala/scalan/primitives/Structs.scala
@@ -552,7 +552,7 @@ trait StructsDslExp extends StructsDsl with Expressions with EffectsExp with Vie
   }
 
   override def containSyms(e: Any): List[Exp[Any]] = e match {
-    case SimpleStruct(tag,fields) => fields.collect { case (k, v: Sym[_]) => v }.toList
+    case SimpleStruct(tag,fields) => fields.collect { case (k, v: Exp[_]) => v }.toList
     case FieldUpdate(s, fn, v) => List(v)
     case FieldApply(s,x) => Nil
     case _ => super.containSyms(e)

--- a/core/src/main/scala/scalan/staged/Expressions.scala
+++ b/core/src/main/scala/scalan/staged/Expressions.scala
@@ -425,10 +425,14 @@ trait Expressions extends BaseExp { scalan: ScalanExp =>
   /**
    * A Sym is a symbolic reference used internally to refer to expressions.
    */
-  object Sym { private var currId = 0 }
-  case class Sym[+T](id: Int = {Sym.currId += 1; Sym.currId})
-                    (implicit et: LElem[T]) extends Exp[T]
-  {
+  object Sym {
+    private var currId = 0
+    def fresh[T: LElem]: Exp[T] = {
+      currId += 1
+      Sym(currId)
+    }
+  }
+  case class Sym[+T](id: Int)(implicit et: LElem[T]) extends Exp[T] {
     override def elem: Elem[T @uncheckedVariance] = this match {
       case Def(d) => d.selfType
       case _ => et.value
@@ -440,7 +444,7 @@ trait Expressions extends BaseExp { scalan: ScalanExp =>
     def toStringWithDefinition = toStringWithType + definition.map(d => s" = $d").getOrElse("")
   }
 
-  def fresh[T](implicit et: LElem[T]): Exp[T] = new Sym[T]()
+  def fresh[T: LElem]: Exp[T] = Sym.fresh[T]
 
   case class TableEntrySingle[T](sym: Exp[T], rhs: Def[T], lambda: Option[Exp[_]]) extends TableEntry[T]
 


### PR DESCRIPTION
This way, we can place a conditional breakpoint specifically on Sym
construction for a given id.