### PR TITLE
[lms] use simple Struct in cake

### DIFF
--- a/lms-backend/core/src/main/scala/scalan/compilation/lms/LmsBackend.scala
+++ b/lms-backend/core/src/main/scala/scalan/compilation/lms/LmsBackend.scala
@@ -66,7 +66,7 @@ abstract class LmsBackendFacade extends ObjectOpsExtExp with LiftVariables with 
 // Not clear whether this is due to our or LMS error
 // Replace StructExpOptCommon with StructExp if needed to verify codegen works correctly;
 // otherwise they can get optimized out
-  with MiscOpsExtExp with StructExpOptCommon with Effects {
+  with MiscOpsExtExp with StructExp with Effects {
   def toStringWithDefinition(x: Exp[_]) = s"$x: ${x.tp}" + (x match {
     case sym: Sym[_] =>
       findDefinition(sym) match {


### PR DESCRIPTION
This fix is required for scalan-ml SVDpp Train with using LmsCompilerScala.
@alexeyr advised me to try this way.