### PR TITLE
Top trait for Linear Algebra sub-project

### DIFF
--- a/linear-algebra/src/main/scala/scalan/linalgebra/LADsl.scala
+++ b/linear-algebra/src/main/scala/scalan/linalgebra/LADsl.scala
@@ -1,0 +1,12 @@
+package scalan.linalgebra
+
+import scalan.collections.{CollectionsDsl, CollectionsDslStd, CollectionsDslExp}
+
+trait LADsl extends CollectionsDsl
+                with MatricesDsl with VectorsDsl
+
+trait LADslStd extends CollectionsDslStd
+                with LADsl with MatricesDslStd with VectorsDslStd
+
+trait LADslExp extends CollectionsDslExp
+                with LADsl with MatricesDslExp with VectorsDslExp


### PR DESCRIPTION
@aslesarenko 
Added `LADsl` that comprises `Vectors` and `Matrices` traits.
If it's OK, I'll push next commit replacing all references of `VectorsDsl***` and `MatricesDsl***` with `LADsl***`.