### PR TITLE
[LA] Moving into LADsl.

### DIFF
--- a/linear-algebra/src/main/scala/scalan/linalgebra/Matrices.scala
+++ b/linear-algebra/src/main/scala/scalan/linalgebra/Matrices.scala
@@ -1,10 +1,10 @@
 package scalan.linalgebra
 
 import scalan._
-import scalan.common.OverloadHack.{Overloaded3, Overloaded2, Overloaded1}
+import scalan.common.OverloadHack.{Overloaded1, Overloaded2, Overloaded3}
 import scala.annotation.unchecked.uncheckedVariance
 
-trait Matrices extends Vectors { self: MatricesDsl =>
+trait Matrices { self: LADsl =>
 
   type Matr[T] = Rep[Matrix[T]]
 
@@ -499,7 +499,7 @@ trait Matrices extends Vectors { self: MatricesDsl =>
   }
 }
 
-trait MatricesDsl extends impl.MatricesAbs with VectorsDsl { self: ScalanDsl =>
+trait MatricesDsl extends impl.MatricesAbs { self: LADsl =>
 
 //  type MatrCompanion = Rep[MatrixCompanion]
 
@@ -534,6 +534,6 @@ trait MatricesDsl extends impl.MatricesAbs with VectorsDsl { self: ScalanDsl =>
   }
 }
 
-trait MatricesDslStd extends impl.MatricesStd with VectorsDslStd
+trait MatricesDslStd extends impl.MatricesStd { self: LADslStd => }
 
-trait MatricesDslExp extends impl.MatricesExp with VectorsDslExp
+trait MatricesDslExp extends impl.MatricesExp { self: LADslExp => }

--- a/linear-algebra/src/main/scala/scalan/linalgebra/Vectors.scala
+++ b/linear-algebra/src/main/scala/scalan/linalgebra/Vectors.scala
@@ -6,10 +6,10 @@ package scalan.linalgebra
 
 import scalan._
 import scalan.collections.{CollectionsDsl, CollectionsDslStd, CollectionsDslExp}
-import scalan.common.OverloadHack.{Overloaded2, Overloaded1}
+import scalan.common.OverloadHack.{Overloaded1, Overloaded2}
 import scala.annotation.unchecked.uncheckedVariance
 
-trait Vectors { self: VectorsDsl =>
+trait Vectors { self: LADsl =>
 
   type Vec[T] = Rep[Vector[T]]
 
@@ -504,7 +504,7 @@ trait Vectors { self: VectorsDsl =>
   }
 }
 
-trait VectorsDsl extends CollectionsDsl with impl.VectorsAbs {
+trait VectorsDsl extends impl.VectorsAbs { self: LADsl =>
 
 //  type VecCompanion = Rep[VectorCompanion]
 
@@ -535,7 +535,7 @@ trait VectorsDsl extends CollectionsDsl with impl.VectorsAbs {
   }
 }
 
-trait VectorsDslStd extends CollectionsDslStd with impl.VectorsStd {
+trait VectorsDslStd extends impl.VectorsStd { self: LADslStd =>
 
   def dotSparse[T: Elem](xIndices: Coll[Int], xValues: Coll[T], yIndices: Coll[Int], yValues: Coll[T])
                         (implicit n: Numeric[T]): Rep[T] = {
@@ -570,7 +570,7 @@ trait VectorsDslStd extends CollectionsDslStd with impl.VectorsStd {
   }
 }
 
-trait VectorsDslExp extends CollectionsDslExp with impl.VectorsExp {
+trait VectorsDslExp extends impl.VectorsExp { self: LADslExp =>
   def dotSparse[T: Elem](xIndices: Coll[Int], xValues: Coll[T], yIndices: Coll[Int], yValues: Coll[T])
                         (implicit n: Numeric[T]): Rep[T] = {
     DotSparse(xIndices.arr, xValues.arr, yIndices.arr, yValues.arr)

--- a/linear-algebra/src/main/scala/scalan/linalgebra/impl/MatricesImpl.scala
+++ b/linear-algebra/src/main/scala/scalan/linalgebra/impl/MatricesImpl.scala
@@ -9,7 +9,7 @@ import scalan.meta.ScalanAst._
 package impl {
 // Abs -----------------------------------
 trait MatricesAbs extends scalan.ScalanDsl with Matrices {
-  self: MatricesDsl =>
+  self: LADsl =>
 
   // single proxy for each type family
   implicit def proxyMatrix[T](p: Rep[Matrix[T]]): Matrix[T] = {
@@ -414,7 +414,7 @@ trait MatricesAbs extends scalan.ScalanDsl with Matrices {
 
 // Std -----------------------------------
 trait MatricesStd extends scalan.ScalanDslStd with MatricesDsl {
-  self: MatricesDslStd =>
+  self: LADslStd =>
   lazy val Matrix: Rep[MatrixCompanionAbs] = new MatrixCompanionAbs {
   }
 
@@ -477,7 +477,7 @@ trait MatricesStd extends scalan.ScalanDslStd with MatricesDsl {
 
 // Exp -----------------------------------
 trait MatricesExp extends scalan.ScalanDslExp with MatricesDsl {
-  self: MatricesDslExp =>
+  self: LADslExp =>
   lazy val Matrix: Rep[MatrixCompanionAbs] = new MatrixCompanionAbs {
   }
 
@@ -1975,7 +1975,7 @@ trait MatricesExp extends scalan.ScalanDslExp with MatricesDsl {
 }
 
 object Matrices_Module extends scalan.ModuleInfo {
-  val dump = "H4sIAAAAAAAAAM1XS2wbRRie9SN+RU5bWggSFiEYEIjGKQgVKYcqOAlq5SZRNlTIVKDxeuxumZ1ddsbB5tBjD3BDXDlUQuLSC+qBA6gXhIQ4cEIIiVMPnEpR1QM9gfhn9uFdZ52QyET1YbQ7j//xfd8//vfmPZTlLnqeG5hitmARgRd09bzMRVVfZcIUg4t2u0fJCunc+fL1W/Ppr79NoZkmmrqC+QqnTVTwHlb7Tvisi3YDFTAzCBe2ywV6pqE81AybUmII02Y107J6ArcoqTVMLpYaKNOy24MP0DWkNdAxw2aGSwTR6xRzTrg/nycyIjN8L6j3wYYz9MFqMotaJIttF5sCwgcfx7z9W8TRB8xmA0ugsh/ahiPDgj0503JsVwQucmDuit0OXjMMwwQ60biKd3ANXHRrunBN1oWTJQcb7+MuWYctcnsGAuaEdrYHjnpPN1CRizYAdN5yqJrpOwghYOAVFcTCEJ+FEJ8FiU9VJ66JqfkRloubrt0fIO+npRHqO2Di5X1MBBbIKmtXP75svPNQL1kpebgvQ8mpDKfA0NNj1KCoABx/2PqUP3jzxtkUKjZR0eTLLS5cbIgo5T5aJcyYLVTMIYDY7QJb8+PYUl6WYc+IJAqGbTmYgSUfymngiZqGKeRmOTftszMG+pxwSLBV6ztamO/cmHyVbuqY0s27T55+7o/Vt1MoFXdRAJM6CN8NjAo0dRGDHPq+cTnOCKRtK4TlUOgPx9wezkMYXrj7Z/v7RXQ5FYLn+/pvfIGJLP/1l9LPL55LoXxTqXuN4m4T8OOrlFgbbt1moony9g5xvZXcDqbyKZG/XJt0cI8KH9UoHGmAQ6C5sXXoEInVktK8FgBQ8mS7bjNSXdus/qX/+NlNqUoXTXsrXmH+Y579+7dyRyjBCpR3rUuY9ggPIE5DTcdBL9bDStiXDbU0G4YlhwpYYD0LjPQsluTGRc+OE45DNl3Tgotqh7z23Tdv3b+9nlXaOeFjp0L3rg0fuiGMMjttETydZyJJMEUPFd22yPH5B+a7Nz4RShpaP34rbbSuQvJL6txTe6gkuB2/un791P0v3ntMVXW+ZQoLO9XFA9R0UIL/Y82iOJHluv8voZR+Jr44s0IYJyBj4VVkhPNwi7dSjwaZi6Itx1PhrCcLoGd2xHTMQCVyNBLRrDYirhTZDuLIyDrcV6PJKVVCNVbGqxEgfHyrcZLeO3c7hbIXULYD1c0bKNuye6wdcAP/uYL0xRvBnBbnBrjALrZCLtRvDg1zHolabSxp8bwOdj3uAnG0QjOu/eFhroCpSzDrS3q/MA51O8jhdHJCi2p89SBaLkuFSVomLuUn4paPSskJCVUixy48GuIyhZ9Morh2x3NoiSSfzsHprUR9T1ZdJVjkk78lT0bMHpWuRlN59ERVbpu4azNMJ9m+TEAE5RU/rslfMXHLR3bF7E7oYGqIZD+ViGcauqbDa2UManvwV5KN0Rq2TDo4k+h3L03u5iWJTw8IJ2bxMKjJ8c5wj78xr4zKbhId95sVagJDXdJysZ+4i+bH9DG63xoC6tcefr7+0k+3fldNdVE2mfD1wMJP9mgzPQJhEAF8g0eCBlXJxlMF/C+w/EV1ExEAAA=="
+  val dump = "H4sIAAAAAAAAAM1XS2wbRRie9SN+RU5bWggSFiEYEIjGKQgVKYcqOAlq5SZRNlTIVKDxeuxumZ1ddsbB5tBjD3BDXDlUQuLSC+qBA6gXhIQ4cEIIiVMPnEpR1QM9gfhn9uFdZ52QyET1YbQ7j//xfd8//vfmPZTlLnqeG5hitmARgRd09bzMRVVfZcIUg4t2u0fJCunc+fL1W/Ppr79NoZkmmrqC+QqnTVTwHlb7Tvisi3YDFTAzCBe2ywV6pqE81AybUmII02Y107J6ArcoqTVMLpYaKNOy24MP0DWkNdAxw2aGSwTR6xRzTrg/nycyIjN8L6j3wYYz9MFqMotaJIttF5sCwgcfx7z9W8TRB8xmA0ugsh/ahiPDgj0503JsVwQucmDuit0OXjMMwwQ60biKd3ANXHRrunBN1oWTJQcb7+MuWYctcnsGAuaEdrYHjnpPN1CRizYAdN5yqJrpOwghYOAVFcTCEJ+FEJ8FiU9VJ66JqfkRloubrt0fIO+npRHqO2Di5X1MBBbIKmtXP75svPNQL1kpebgvQ8mpDKfA0NNj1KCoABx/2PqUP3jzxtkUKjZR0eTLLS5cbIgo5T5aJcyYLVTMIYDY7QJb8+PYUl6WYc+IJAqGbTmYgSUfymngiZqGKeRmOTftszMG+pxwSLBV6ztamO/cmHyVbuqY0s27T55+7o/Vt1MoFXdRAJM6CN8NjAo0dRGDHPq+cTnOCKRtK4TlUOgPx9wezkMYXrj7Z/v7RXQ5FYLn+/pvfIGJLP/1l9LPL55LoXxTqXuN4m4T8OOrlFgbbt1moony9g5xvZXcDqbyKZG/XJt0cI8KH9UoHGmAQ6C5sXXoEInVktK8FgBQ8mS7bjNSXdus/qX/+NlNqUoXTXsrXmH+Y579+7dyRyjBCpR3rUuY9ggPIE5DTcdBL9bDStiXDbU0G4YlhwpYYD0LjPQsluTGRc+OE45DNl3Tgotqh7z23Tdv3b+9nlXaOeFjp0L3rg0fuiGMMjttETydZyJJMEUPFd22yPH5B+a7Nz4RShpaP34rbbSuQvJL6txTe6gkuB2/un791P0v3ntMVXW+ZQoLO9XFA9R0UIL/Y82iOJHluv8voZR+Jr44s0IYJyBj4VVkhPNwi7dSjwaZi6Itx1PhrCcLoGd2xHTMQCVyNBLRrDYirhTZDuLIyDrcV6PJKVVCNVbGqxEgfHyrcZLeO3c7hbIXULYD1c0bKNuye6wdcAP/uYL0xRvBnBbnBrjALrZCLtRvDg1zHolabSxp8bwOdj3uAnG0QjOu/eFhroCpSzDrS3q/MA51O8jhdHJCi2p89SBaLkuFSVomLuUn4paPSskJCVUixy48GuIyhZ9Morh2x3NoiSSfzsHprUR9T1ZdJVjkk78lT0bMHpWuRlN59ERVbpu4azNMJ9m+TEAE5RU/rslfMXHLR3bF7E7oYGqIZD+ViGcauqbDa2UManvwV5KN0Rq2TDo4k+h3L03u5iWJTw8IJ2bxMKjJ8c5wj78xr4zKbhId95sVagJDXdJysZ+4i+bH9DG63xoC6tcefr7+0k+3fldNdVE2mfD1wMJP9mgzHQcq21iGr+9IuKAn2XKqUP8FwxvQbw0RAAA="
 }
 }
 

--- a/linear-algebra/src/main/scala/scalan/linalgebra/impl/VectorsImpl.scala
+++ b/linear-algebra/src/main/scala/scalan/linalgebra/impl/VectorsImpl.scala
@@ -2,7 +2,7 @@ package scalan.linalgebra
 
 import scalan._
 import scalan.collections.{CollectionsDsl, CollectionsDslStd, CollectionsDslExp}
-import scalan.common.OverloadHack.{Overloaded2, Overloaded1}
+import scalan.common.OverloadHack.{Overloaded1, Overloaded2}
 import scala.annotation.unchecked.uncheckedVariance
 import scala.reflect.runtime.universe.{WeakTypeTag, weakTypeTag}
 import scalan.meta.ScalanAst._
@@ -10,7 +10,7 @@ import scalan.meta.ScalanAst._
 package impl {
 // Abs -----------------------------------
 trait VectorsAbs extends scalan.ScalanDsl with Vectors {
-  self: VectorsDsl =>
+  self: LADsl =>
 
   // single proxy for each type family
   implicit def proxyVector[T](p: Rep[Vector[T]]): Vector[T] = {
@@ -414,7 +414,7 @@ trait VectorsAbs extends scalan.ScalanDsl with Vectors {
 
 // Std -----------------------------------
 trait VectorsStd extends scalan.ScalanDslStd with VectorsDsl {
-  self: VectorsDslStd =>
+  self: LADslStd =>
   lazy val Vector: Rep[VectorCompanionAbs] = new VectorCompanionAbs {
   }
 
@@ -477,7 +477,7 @@ trait VectorsStd extends scalan.ScalanDslStd with VectorsDsl {
 
 // Exp -----------------------------------
 trait VectorsExp extends scalan.ScalanDslExp with VectorsDsl {
-  self: VectorsDslExp =>
+  self: LADslExp =>
   lazy val Vector: Rep[VectorCompanionAbs] = new VectorCompanionAbs {
   }
 
@@ -1915,7 +1915,7 @@ trait VectorsExp extends scalan.ScalanDslExp with VectorsDsl {
 }
 
 object Vectors_Module extends scalan.ModuleInfo {
-  val dump = "H4sIAAAAAAAAAOVXPWwcRRR+e7++n9hJiCOQsDDmICICn4NAQXIRmbMNRodteZ0IHVHQ3N74PGF2dtmZs+4oIqoIQYdoKSIh0aRBKSiC0iAkREGFEBIFoqAKQVEKIgoQM7M/t+e7808ExhJbjHZnZt97833fe/v2+h1Icw+e4haiiE3bWKBpU9/PcVEyF5ggovOa02hRPI83fv70xRtTyc+/SMBYDTKbiM9zWoOcf7PQdqN7UzSqkEPMwlw4HhfweFV7KFsOpdgSxGFlYtstgeoUl6uEi9kqpOpOo/M2XAGjCkcth1keFtisUMQ55sH8CFYRkeg5p587K27XByurU5Rjp1j3EBEyfOnjqL9/DbtmhzmsYwsYDUJbcVVYck+W2K7jidBFVprbdBrhY4ohOQHHq5fRFipLF82yKTzCmvLNgoust1ATL8stantKBswx3VjvuPo5WYU8Fw0J0JLtUj3TdgFAMvCcDmK6i890hM+0wqdkYo8gSt5BanHVc9od8C8jCdB2pYlndjERWsALrFF6/6L1xn2zYCfUy20VSlafMCMNPTZEDZoKiePXax/yey9fO5uAfA3yhM/VufCQJeKUB2gVEGOO0DFHACKvKdmaGsaW9jIn92yTRM5ybBcxaSmAsih5osQiQm1Wc8WAnSHQZ4WLw61G2zWi804OOa/WTQVRunr7kWef/HXh9QQkel3kpElTCt8LjQrIXJDgBwBk9DgmwFjXCKsh1+6O2R2cRzCcuv1b46sZuJiIwAt87Y0vaSLNf/i+8N3T5xIwUtPqXqSoWZP48QWK7RWv4jBRgxFnC3v+SnYLUXU3kL9sA2+gFhUBqnE4khIOAZND89DFCqtZrXkjBKDgy3bZYbi0uFr63fzmo+tKlR4U/RU/Mf8iZ//8cXRDaMEKSBOBbR7im5QJ3Yt4vhKlwZ6o6BKS972ajo2PTd0jl659IDT0Rrs361fql6X9Wf3eozuwEFafz65eHb/7yZsP6awZqRNhI7c0s4+cCSX+L+YE9GI1WgmqsFbSmd7FQOgxNMOVMX+lEo8tGwdZjePRrB4mJKcn5jHjeMDLE7HXYkE8bIQy0psEJPB6GENKSXtX5gUUYj61lSirJobxqRE7uVY9Qe+cu5WA9KuQ3pDJwquQrjst1gipkJ8wgdvipXDO6KVCQo88ZEfQ62sSuufdFrHeWDAGkrDHatMHIGwDMKWzamhS9cfTZyFDMWuKzQE2PHhiOKKrHrHld30Lv/DlzfN3by2ndak9HpSaC4i2sP+VDcDrAqmKgTEjPS0xMfjEp/R4+j/WtnTHxQFrO+Yzrm01zh0KvY3KHqyGPWeJNYgsgvso52qoxT0OdnAkcKAV9A99LgZ5UsP5fvN9UR4yVY6bsgYddMktxp0eTl0WQ13Gm4yU0siuTZcsZustl+Lnb/5x6b13X3F179DXJ8bk8f9Q2sk46WcOSmpHerzuX2uxs2cGopiUjd2DK3EIZjuwVlC92yKyCe3sStkeWBnEpg+E22PxQVBT40/dPcHGbACPgGNBAlHCEG3iuoeCc3swNSS3zKB5laBfuf/x8ulvb/yi+4S8aoPl/wOLftrj/cG2Sh8EIH/CYyFLSanOWIf7N3B5ruQUEQAA"
+  val dump = "H4sIAAAAAAAAAOVXPWwcRRR+e7++n9hJiCOQsDDmICICn4NAQXIRmbMNRodteZ0IHVHQ3N74PGF2dtmZs+4oIqoIQYdoKSIh0aRBKSiC0iAkREGFEBIFoqAKQVEKIgoQM7M/t+e7808ExhJbjHZnZt97833fe/v2+h1Icw+e4haiiE3bWKBpU9/PcVEyF5ggovOa02hRPI83fv70xRtTyc+/SMBYDTKbiM9zWoOcf7PQdqN7UzSqkEPMwlw4HhfweFV7KFsOpdgSxGFlYtstgeoUl6uEi9kqpOpOo/M2XAGjCkcth1keFtisUMQ55sH8CFYRkeg5p587K27XByurU5Rjp1j3EBEyfOnjqL9/DbtmhzmsYwsYDUJbcVVYck+W2K7jidBFVprbdBrhY4ohOQHHq5fRFipLF82yKTzCmvLNgoust1ATL8stantKBswx3VjvuPo5WYU8Fw0J0JLtUj3TdgFAMvCcDmK6i890hM+0wqdkYo8gSt5BanHVc9od8C8jCdB2pYlndjERWsALrFF6/6L1xn2zYCfUy20VSlafMCMNPTZEDZoKiePXax/yey9fO5uAfA3yhM/VufCQJeKUB2gVEGOO0DFHACKvKdmaGsaW9jIn92yTRM5ybBcxaSmAsih5osQiQm1Wc8WAnSHQZ4WLw61G2zWi804OOa/WTQVRunr7kWef/HXh9QQkel3kpElTCt8LjQrIXJDgBwBk9DgmwFjXCKsh1+6O2R2cRzCcuv1b46sZuJiIwAt87Y0vaSLNf/i+8N3T5xIwUtPqXqSoWZP48QWK7RWv4jBRgxFnC3v+SnYLUXU3kL9sA2+gFhUBqnE4khIOAZND89DFCqtZrXkjBKDgy3bZYbi0uFr63fzmo+tKlR4U/RU/Mf8iZ//8cXRDaMEKSBOBbR7im5QJ3Yt4vhKlwZ6o6BKS972ajo2PTd0jl659IDT0Rrs361fql6X9Wf3eozuwEFafz65eHb/7yZsP6awZqRNhI7c0s4+cCSX+L+YE9GI1WgmqsFbSmd7FQOgxNMOVMX+lEo8tGwdZjePRrB4mJKcn5jHjeMDLE7HXYkE8bIQy0psEJPB6GENKSXtX5gUUYj61lSirJobxqRE7uVY9Qe+cu5WA9KuQ3pDJwquQrjst1gipkJ8wgdvipXDO6KVCQo88ZEfQ62sSuufdFrHeWDAGkrDHatMHIGwDMKWzamhS9cfTZyFDMWuKzQE2PHhiOKKrHrHld30Lv/DlzfN3by2ndak9HpSaC4i2sP+VDcDrAqmKgTEjPS0xMfjEp/R4+j/WtnTHxQFrO+Yzrm01zh0KvY3KHqyGPWeJNYgsgvso52qoxT0OdnAkcKAV9A99LgZ5UsP5fvN9UR4yVY6bsgYddMktxp0eTl0WQ13Gm4yU0siuTZcsZustl+Lnb/5x6b13X3F179DXJ8bk8f9Q2sk46WcOSmpHerzuX2uxs2cGopiUjd2DK3EIZjuwVlC92yKyCe3sStkeWBnEpg+E22PxQVBT40/dPcHGbACPgGNBAlHCEG3iuoeCc3swNSS3zKB5laBfuf/x8ulvb/yi+4S8aoPl/wOLftrj/UEvTunqnPz/jkUr1aSaYh3p32o9hPYPEQAA"
 }
 }
 

--- a/linear-algebra/src/test/scala/scalan/linalgebra/Issue186Test.scala
+++ b/linear-algebra/src/test/scala/scalan/linalgebra/Issue186Test.scala
@@ -7,7 +7,7 @@ import scalan._
 class Issue186Test extends BaseCtxTests {
 
   test("issue186") {
-    class Ctx extends TestContext with MatricesDslExp { override def isInvokeEnabled(d: Def[_], m: Method) = false }
+    class Ctx extends TestContext with LADslExp { override def isInvokeEnabled(d: Def[_], m: Method) = false }
     val ctx = new Ctx
     import ctx._
     def sparseData2denseData = fun { data: Rep[SparseVectorData[Double]] =>

--- a/linear-algebra/src/test/scala/scalan/linalgebra/LASuite.scala
+++ b/linear-algebra/src/test/scala/scalan/linalgebra/LASuite.scala
@@ -17,7 +17,7 @@ class LASuite extends BaseShouldTests {
   lazy val len = 5
 
   "in seq context1" should "execute functions" in {
-    val ctx = new MatricesDslStd with LinearAlgebraExamples {}
+    val ctx = new LADslStd with LinearAlgebraExamples {}
     val i = 3
     val in = (vector1, (len, i))
     val res = ctx.applySparseVector(in)
@@ -26,7 +26,7 @@ class LASuite extends BaseShouldTests {
   }
 
   "ConstVector" should "return same results as DenseVector" in {
-    val ctx = new MatricesDslStd with LinearAlgebraExamples {}
+    val ctx = new LADslStd with LinearAlgebraExamples {}
     val cv = ctx.constVector((2.0, 3))
     val dv = ctx.denseVector(Array(2.0, 2.0, 2.0))
     val sv = ctx.sparseVector((Array(0, 1, 2), (Array(2.0, 2.0, 2.0), 3)))
@@ -55,7 +55,7 @@ class LASuite extends BaseShouldTests {
   }
 
   "ConstMatrix" should "return same results as DenseFlatMatrix" in {
-    val ctx = new MatricesDslStd with LinearAlgebraExamples {}
+    val ctx = new LADslStd with LinearAlgebraExamples {}
     val cm = ctx.constMatrix((2.0, (3, 2)))
     val fm = ctx.flatMatrix((Array(2.0, 2.0, 2.0, 2.0, 2.0, 2.0), 3))
     val dv = ctx.denseVector(Array(2.0, 2.0, 2.0))
@@ -74,7 +74,7 @@ class LASuite extends BaseShouldTests {
   }
 
   "DiagonalMatrix" should "return same results as DenseFlatMatrix" in {
-    val ctx = new MatricesDslStd with LinearAlgebraExamples {}
+    val ctx = new LADslStd with LinearAlgebraExamples {}
     val dm = ctx.diagonalMatrix(Array(1.0, 2.0, 3.0, 4.0))
     val fm = ctx.flatMatrix((Array(1.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0, 4.0), 4))
     val dv = ctx.denseVector(Array(2.0, 3.0, 4.0, 5.0))

--- a/linear-algebra/src/test/scala/scalan/linalgebra/LinearAlgebraExamples.scala
+++ b/linear-algebra/src/test/scala/scalan/linalgebra/LinearAlgebraExamples.scala
@@ -1,6 +1,6 @@
 package scalan.linalgebra
 
-trait LinearAlgebraExamples extends MatricesDsl {
+trait LinearAlgebraExamples extends LADsl {
   def mvm[T](matrix: Matr[T], vector: Vec[T])(implicit eT: Elem[T], n: Numeric[T]): Vec[T] =
     DenseVector(matrix.rows.mapBy( fun{ r => r dot vector }))
 

--- a/linear-algebra/src/test/scala/scalan/linalgebra/MvmTests.scala
+++ b/linear-algebra/src/test/scala/scalan/linalgebra/MvmTests.scala
@@ -11,7 +11,7 @@ class MvmTests extends BaseViewTests {
 
   class Ctx extends TestCompilerContext {
 
-    class ScalanCake extends ScalanDslExp with LinearAlgebraExamples with MatricesDslExp {
+    class ScalanCake extends ScalanDslExp with LinearAlgebraExamples with LADslExp {
       override val cacheElems = false
 
       def noTuples[A, B](f: Rep[A => B]): Boolean = {

--- a/linear-algebra/src/test/scala/scalan/performance/mvm.scala
+++ b/linear-algebra/src/test/scala/scalan/performance/mvm.scala
@@ -2,7 +2,7 @@ package scalan.performance
 
 import org.scalameter.api._
 
-import scalan.linalgebra.{MatricesDslStd, LinearAlgebraExamples}
+import scalan.linalgebra.{LADslStd, LinearAlgebraExamples}
 
 class mvm extends BaseBenchmark {
   //def main(args:Array[String]) {
@@ -72,7 +72,7 @@ class mvm extends BaseBenchmark {
     val inFD = Gen.single("fmdv")((fmat,dvec))
     val inFS = Gen.single("fmsv")((fmat,svec))
 
-    val ctx = new MatricesDslStd with LinearAlgebraExamples
+    val ctx = new LADslStd with LinearAlgebraExamples
 
     performance of "mvm" config (
       exec.minWarmupRuns -> 5,

--- a/lms-backend/linear-algebra/src/it/scala/scalan/compilation/lms/cxx/sharedptr/JNILinAlgItTests.scala
+++ b/lms-backend/linear-algebra/src/it/scala/scalan/compilation/lms/cxx/sharedptr/JNILinAlgItTests.scala
@@ -26,7 +26,7 @@ trait JNILinAlgProg extends LinearAlgebraExamples with JNIExtractorOps {
 
 class JNILinAlgItTests extends BaseItTests[JNILinAlgProg](???) {
 
-  class ProgExp extends MatricesDslExp with JNILinAlgProg with JNIExtractorOpsExp
+  class ProgExp extends LADslExp with JNILinAlgProg with JNIExtractorOpsExp
 
   val prog = new LmsCompilerCxx(new ProgExp) with JNIBridge with LinAlgBridge {
     override val lms = new LinAlgCxxShptrLmsBackend

--- a/lms-backend/linear-algebra/src/it/scala/scalan/linalgebra/LmsLinAlgItTests.scala
+++ b/lms-backend/linear-algebra/src/it/scala/scalan/linalgebra/LmsLinAlgItTests.scala
@@ -7,8 +7,8 @@ import scalan.compilation.lms.source2bin.SbtConfig
 import scalan.compilation.lms.uni._
 import scalan.it.BaseItTests
 
-abstract class LmsLinAlgItTests extends BaseItTests[LinearAlgebraExamples](new MatricesDslStd with LinearAlgebraExamples) {
-  class ProgExp extends MatricesDslExp with JNIExtractorOpsExp with LinearAlgebraExamples
+abstract class LmsLinAlgItTests extends BaseItTests[LinearAlgebraExamples](new LADslStd with LinearAlgebraExamples) {
+  class ProgExp extends LADslExp with JNIExtractorOpsExp with LinearAlgebraExamples
 
   val progStaged = new LinAlgLmsCompilerScala(new ProgExp)
 

--- a/lms-backend/linear-algebra/src/main/scala/scalan/compilation/lms/linalgebra/LinAlgBridge.scala
+++ b/lms-backend/linear-algebra/src/main/scala/scalan/compilation/lms/linalgebra/LinAlgBridge.scala
@@ -2,10 +2,10 @@ package scalan.compilation.lms.linalgebra
 
 import scalan.compilation.lms.collections.CollectionsBridgeScala
 import scalan.compilation.lms.{CoreBridge, CoreLmsBackend}
-import scalan.linalgebra.{VectorsDslExp, LinAlgMethodMappingDSL}
+import scalan.linalgebra.{LADslExp, LinAlgMethodMappingDSL}
 
 trait LinAlgBridge extends CoreBridge with LinAlgMethodMappingDSL {
-  override val scalan: VectorsDslExp
+  override val scalan: LADslExp
   import scalan._
 
   val lms: CoreLmsBackend with VectorOpsExp

--- a/lms-backend/linear-algebra/src/main/scala/scalan/compilation/lms/linalgebra/LinAlgLmsCompilerScala.scala
+++ b/lms-backend/linear-algebra/src/main/scala/scalan/compilation/lms/linalgebra/LinAlgLmsCompilerScala.scala
@@ -2,12 +2,12 @@ package scalan.compilation.lms.linalgebra
 
 import scalan.compilation.lms.ScalaCoreLmsBackend
 import scalan.compilation.lms.scalac.{ScalaCoreCodegen, LmsCompilerScala}
-import scalan.linalgebra.VectorsDslExp
+import scalan.linalgebra.LADslExp
 
 class ScalaLinAlgLmsBackend extends ScalaCoreLmsBackend with VectorOpsExp { self =>
   override val codegen = new ScalaCoreCodegen[self.type](self) with ScalaGenVectorOps
 }
 
-class LinAlgLmsCompilerScala[+ScalanCake <: VectorsDslExp](_scalan: ScalanCake) extends LmsCompilerScala(_scalan) with LinAlgBridgeScala {
+class LinAlgLmsCompilerScala[+ScalanCake <: LADslExp](_scalan: ScalanCake) extends LmsCompilerScala(_scalan) with LinAlgBridgeScala {
   override val lms = new ScalaLinAlgLmsBackend
 }

--- a/lms-backend/linear-algebra/src/main/scala/scalan/compilation/lms/linalgebra/LinAlgLmsCompilerUni.scala
+++ b/lms-backend/linear-algebra/src/main/scala/scalan/compilation/lms/linalgebra/LinAlgLmsCompilerUni.scala
@@ -3,7 +3,7 @@ package scalan.compilation.lms.linalgebra
 import scalan.compilation.lms.cxx.sharedptr.CxxCoreCodegen
 import scalan.compilation.lms.scalac.ScalaCoreCodegen
 import scalan.compilation.lms.uni.{LmsBackendUni, LmsCompilerUni}
-import scalan.linalgebra.VectorsDslExp
+import scalan.linalgebra.LADslExp
 import scalan.{JNIExtractorOpsExp, ScalanDslExp}
 
 class LinAlgLmsBackendUni extends LmsBackendUni with VectorOpsExp { self =>
@@ -11,6 +11,6 @@ class LinAlgLmsBackendUni extends LmsBackendUni with VectorOpsExp { self =>
   override val nativeCodegen = new CxxCoreCodegen[self.type](self) with CxxShptrGenVectorOps
 }
 
-class LinAlgLmsCompilerUni[+ScalanCake <: ScalanDslExp with VectorsDslExp with JNIExtractorOpsExp](_scalan: ScalanCake) extends LmsCompilerUni[ScalanCake](_scalan) with LinAlgBridge {
+class LinAlgLmsCompilerUni[+ScalanCake <: ScalanDslExp with LADslExp with JNIExtractorOpsExp](_scalan: ScalanCake) extends LmsCompilerUni[ScalanCake](_scalan) with LinAlgBridge {
   override val lms = new LinAlgLmsBackendUni
 }

--- a/lms-backend/tests/src/it/scala/HelloScalan.scala
+++ b/lms-backend/tests/src/it/scala/HelloScalan.scala
@@ -5,9 +5,9 @@ import java.io.File
 import scalan.compilation.GraphVizConfig
 import scalan.compilation.lms.linalgebra.LinAlgLmsCompilerScala
 import scalan.it.BaseItTests
-import scalan.linalgebra.{MatricesDsl, MatricesDslExp, MatricesDslStd}
+import scalan.linalgebra.{LADsl, LADslStd, LADslExp}
 
-trait HelloScalan extends MatricesDsl {
+trait HelloScalan extends LADsl {
   lazy val run = fun { p: Rep[(Array[Array[Double]], Array[Double])] =>
     val Pair(m, v) = p
     val width = m(0).length
@@ -22,7 +22,7 @@ trait HelloScalan extends MatricesDsl {
 }
 
 // to run: scalan-lms-backend/test:runMain HelloScalanStd
-object HelloScalanStd extends MatricesDslStd with HelloScalan {
+object HelloScalanStd extends LADslStd with HelloScalan {
   def result = run(input)
 
   def main(args: Array[String]) = {
@@ -35,7 +35,7 @@ object HelloScalanExp {
   // allows use of standard Scala library, commented out to make tests faster
   // override val defaultCompilerConfig = CompilerConfig(Some("2.11.7"), Seq.empty)
 
-  val program = new MatricesDslExp with HelloScalan
+  val program = new LADslExp with HelloScalan
 
   val compiler = new LinAlgLmsCompilerScala(program)
   import compiler._

--- a/lms-backend/tests/src/it/scala/scalan/compilation/lms/uni/UniCompilerItTests.scala
+++ b/lms-backend/tests/src/it/scala/scalan/compilation/lms/uni/UniCompilerItTests.scala
@@ -6,7 +6,7 @@ import scalan._
 import scalan.compilation.lms.linalgebra.{LinAlgBridge, LinAlgLmsCompilerUni}
 import scalan.graphs.{GraphsDslExp, GraphsDslStd, GraphTestInputs, MsfFuncs}
 import scalan.it.BaseItTests
-import scalan.linalgebra.{LinearAlgebraExamples, MatricesDslExp, MatricesDslStd}
+import scalan.linalgebra.{LinearAlgebraExamples, LADslStd, LADslExp}
 
 /**
  * Created by adel on 5/15/15.
@@ -80,11 +80,11 @@ trait UniCompilerTestProg extends MsfFuncs with LinearAlgebraExamples {
 
 }
 
-class UniCompilerItTests extends BaseItTests[UniCompilerTestProg](new GraphsDslStd with MatricesDslStd with UniCompilerTestProg) with GraphTestInputs {
+class UniCompilerItTests extends BaseItTests[UniCompilerTestProg](new GraphsDslStd with LADslStd with UniCompilerTestProg) with GraphTestInputs {
 
   val in3Arrays = (Array(2, 3), (Array(1, 4), Array(1, -1)))
 
-  class ProgExp extends GraphsDslExp with MatricesDslExp with UniCompilerTestProg with JNIExtractorOpsExp
+  class ProgExp extends GraphsDslExp with LADslExp with UniCompilerTestProg with JNIExtractorOpsExp
 
   val progStaged = new LinAlgLmsCompilerUni(new ProgExp) with LinAlgBridge
 


### PR DESCRIPTION
@aslesarenko 
Replaced all references of `VectorsDsl***` and `MatricesDsl***` with `LADsl***`. Updated boilerplate for `Matrices` and `Vectors`.